### PR TITLE
Handling duplicate Entry in CreatingIndex

### DIFF
--- a/Rebus.MySql/MySql/Sagas/MySqlServerMagic.cs
+++ b/Rebus.MySql/MySql/Sagas/MySqlServerMagic.cs
@@ -1,0 +1,15 @@
+using Rebus.Sagas;
+
+namespace Rebus.MySql.Sagas
+{
+    static class MySqlServerMagic
+    {
+        /// <summary>
+        /// Error code that is emitted on PK violations
+        /// https://dev.mysql.com/doc/refman/5.7/en/error-messages-server.html
+        /// </summary>
+        public const int PrimaryKeyViolationNumber = 1062;
+
+    }
+
+}


### PR DESCRIPTION
When Creating the index an Primary key violation can happen. This is already fixed in SQL Server and I applied the same logic for MySql.
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
