### PR TITLE
Change casing of Rebus Package Reference

### DIFF
--- a/Rebus.MySql/Rebus.MySql.csproj
+++ b/Rebus.MySql/Rebus.MySql.csproj
@@ -47,7 +47,7 @@
     <None Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="rebus" Version="4.0.0-b05" />
+    <PackageReference Include="Rebus" Version="4.0.0-b05" />
     <PackageReference Include="MySql.Data" Version="7.0.7-m61" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.6' ">


### PR DESCRIPTION
Hi,

This will change the casing of the Package Reference for Rebus. (to work with project.json files)

Kind Regards
  Rob 
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
