### PR TITLE
RunSynchronously will throw error when AutocallyCreateTables is set

### DIFF
--- a/Rebus.MySql/Config/MySqlConfigurationExtensions.cs
+++ b/Rebus.MySql/Config/MySqlConfigurationExtensions.cs
@@ -33,7 +33,9 @@ namespace Rebus.Config
 
                 if (automaticallyCreateTables)
                 {
-                    subscriptionStorage.EnsureTableIsCreated().RunSynchronously();
+                    var createTableTask = subscriptionStorage.EnsureTableIsCreated();
+                    createTableTask.Wait(); // wait at least 1min to make sure the tables are correctly created.
+                    if (createTableTask.Exception != null) throw createTableTask.Exception;
                 }
 
                 return subscriptionStorage;


### PR DESCRIPTION
Hi, 

When using RunSynchronously, it will throw an error when the taks is already completed. 

"RunSynchronously may not be called on a task that has already completed."

This is maybe not the best solution, but it works for now. If you have another option to execute this async task, syncronously i'm happy to learn :-)

Kind regards
  Rob 
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
