### PR TITLE
Fixing MySQL show tables.

### DIFF
--- a/Rebus.MySql/MySql/Extensions/MySqlConnection.cs
+++ b/Rebus.MySql/MySql/Extensions/MySqlConnection.cs
@@ -10,13 +10,13 @@ namespace Rebus.MySql.Extensions
 
             using (var command = connection.CreateCommand())
             {
-                command.CommandText = "select * from information_schema.tables where table_schema not in ('pg_catalog', 'information_schema')";
+                command.CommandText = "show tables";
 
                 using (var reader = command.ExecuteReader())
                 {
                     while (reader.Read())
                     {
-                        tableNames.Add(reader["table_name"].ToString());
+                        tableNames.Add(reader[0].ToString());
                     }
                 }
             }


### PR DESCRIPTION
The old code would return all tables for the entire database server. This code will only return all tables for the current database, which the connection is related to.

All tests are passing.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
