### PR TITLE
Change UsePostgreSqlAsOneWayClient to UseMySqlAsOneWayClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ _NCrunch_*
 **/packages/*
 !**/packages/build/
 AssemblyInfo_Patch.cs
+/.idea/

--- a/Rebus.MySql/Config/MySqlTransportConfigurationExtensions.cs
+++ b/Rebus.MySql/Config/MySqlTransportConfigurationExtensions.cs
@@ -31,7 +31,7 @@ namespace Rebus.Config
         /// The table specified by <paramref name="tableName"/> will be used to store messages.
         /// The message table will automatically be created if it does not exist.
         /// </summary>
-        public static void UsePostgreSqlAsOneWayClient(this StandardConfigurer<ITransport> configurer, string connectionString, string tableName)
+        public static void UseMySqlAsOneWayClient(this StandardConfigurer<ITransport> configurer, string connectionString, string tableName)
         {
             Configure(configurer, loggerFactory => new MySqlConnectionHelper(connectionString), tableName, null);
 


### PR DESCRIPTION
I was wondering why this function did not exist, so it was incorrectly copied and pasted over.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.

