### PR TITLE
Fix repo for NuGet project

### DIFF
--- a/Rebus.MySql/Rebus.MySql.csproj
+++ b/Rebus.MySql/Rebus.MySql.csproj
@@ -12,7 +12,7 @@
     <Copyright>Copyright 2012</Copyright>
     <PackageTags>rebus queue messaging service bus mysql sql</PackageTags>
     <PackageIcon>little_rebusbus2_copy-500x500.png</PackageIcon>
-    <RepositoryUrl>https://github.com/kendall/Rebus.MySql</RepositoryUrl>
+    <RepositoryUrl>https://github.com/rebus-org/Rebus.MySql</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
The project still pointed to my repo so I changed that, but not sure how it gets generated for your official builds because the repo in the NuGet package points to the main Rebus project, not the MySQL specific project?

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
