### PR TITLE
Change transaction isolation mode to REPEATABLE READ

### DIFF
--- a/Rebus.MySql/MySql/DbConnectionProvider.cs
+++ b/Rebus.MySql/MySql/DbConnectionProvider.cs
@@ -9,8 +9,7 @@ using IsolationLevel = System.Data.IsolationLevel;
 namespace Rebus.MySql
 {
     /// <summary>
-    /// Implementation of <see cref="IDbConnectionProvider"/> that ensures that MARS (multiple active result sets) is enabled on the
-    /// given connection string (possibly by enabling it by itself)
+    /// Implementation of <see cref="IDbConnectionProvider"/>
     /// </summary>
     public class DbConnectionProvider : IDbConnectionProvider
     {
@@ -20,7 +19,7 @@ namespace Rebus.MySql
 
         /// <summary>
         /// Creates the connection provider with the given <paramref name="connectionString"/>.
-        /// Will use <see cref="System.Data.IsolationLevel.ReadCommitted"/> by default on transactions,
+        /// Will use <see cref="System.Data.IsolationLevel.RepeatableRead"/> by default on transactions,
         /// unless another isolation level is set with the <see cref="IsolationLevel"/> property
         /// </summary>
         public DbConnectionProvider(string connectionString, IRebusLoggerFactory rebusLoggerFactory, bool enlistInAmbientTransaction = false)
@@ -136,6 +135,6 @@ namespace Rebus.MySql
         /// <summary>
         /// Gets/sets the isolation level used for transactions
         /// </summary>
-        public IsolationLevel IsolationLevel { get; set; } = IsolationLevel.ReadCommitted;
+        public IsolationLevel IsolationLevel { get; set; } = IsolationLevel.RepeatableRead;
     }
 }


### PR DESCRIPTION
We have been having some issues in production where a single message ends up getting consumed at the same time by multiple threads, which should not happen. I have checked over the SQL code for the transport again and the only thing that makes sense to me is that somehow the first SELECT FOR UPDATE is not blocking correctly, and multiple end up getting through at once. 

Reading through the different isolation levels with MySQL, I suspect the issue is using READ COMMITTED, so I have changed it to use the more restrictive REPEATABLE READ which is the only isolation mode we use for our code (ended up with that years ago) and it's also the default. Could be related to our Percona cluster, but either way I think this is a safer choice. We are monitoring with this change to see if it happens again. If so, we will need to implement a more explicit thread lock for that code (probably using my new semaphore code).

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
