### PR TITLE
Avoid MySQL access during startup if not creating tables

### DIFF
--- a/Rebus.MySql.Tests/Bugs/TestRebusTransactionScopeAndSyncBus.cs
+++ b/Rebus.MySql.Tests/Bugs/TestRebusTransactionScopeAndSyncBus.cs
@@ -39,7 +39,6 @@ namespace Rebus.MySql.Tests.Bugs
 
             _subscriptionStorage = new MySqlSubscriptionStorage(connectionProvider, "Subscriptions", isCentralized: true, loggerFactory);
             _subscriptionStorage.EnsureTableIsCreated();
-            _subscriptionStorage.Initialize();
 
             _subscriberTransport = Using(new MySqlTransport(connectionProvider, "subscriber", loggerFactory, new TplAsyncTaskFactory(loggerFactory), new FakeRebusTime(), new MySqlTransportOptions(connectionProvider)));
             _subscriberTransport.EnsureTableIsCreated();

--- a/Rebus.MySql.Tests/Subscriptions/TestMySqlSubscriptionStorage.cs
+++ b/Rebus.MySql.Tests/Subscriptions/TestMySqlSubscriptionStorage.cs
@@ -86,8 +86,6 @@ namespace Rebus.MySql.Tests.Subscriptions
                 storage.EnsureTableIsCreated();
             }
 
-            storage.Initialize();
-
             return storage;
         }
     }

--- a/Rebus.MySql/MySql/Transport/MySqlTransport.cs
+++ b/Rebus.MySql/MySql/Transport/MySqlTransport.cs
@@ -79,6 +79,7 @@ namespace Rebus.MySql.Transport
         bool _disposed;
         readonly TimeSpan _leaseInterval;
         readonly TimeSpan _leaseTolerance;
+        readonly bool _ensureTablesAreCreated;
         readonly bool _automaticLeaseRenewal;
         readonly TimeSpan _automaticLeaseRenewalInterval;
         readonly Func<string> _leasedByFactory;
@@ -117,6 +118,7 @@ namespace Rebus.MySql.Transport
             _leasedByFactory = options.LeasedByFactory ?? (() => Environment.MachineName);
             _leaseInterval = options.LeaseInterval ?? DefaultLeaseTime;
             _leaseTolerance = options.LeaseInterval ?? DefaultLeaseTolerance;
+            _ensureTablesAreCreated = options.EnsureTablesAreCreated;
 
             var automaticLeaseRenewalInterval = options.LeaseAutoRenewInterval;
 
@@ -168,15 +170,18 @@ namespace Rebus.MySql.Transport
 
         void EnsureTableIsCreated(TableName table)
         {
-            try
+            if (_ensureTablesAreCreated)
             {
-                InnerEnsureTableIsCreated(table);
-            }
-            catch (Exception)
-            {
-                // if it fails the first time, and if it's because of some kind of conflict,
-                // we should run it again and see if the situation has stabilized
-                InnerEnsureTableIsCreated(table);
+                try
+                {
+                    InnerEnsureTableIsCreated(table);
+                }
+                catch (Exception)
+                {
+                    // if it fails the first time, and if it's because of some kind of conflict,
+                    // we should run it again and see if the situation has stabilized
+                    InnerEnsureTableIsCreated(table);
+                }
             }
         }
 


### PR DESCRIPTION
If MySQL is down when Rebus is initialized, if we are not requesting that the tables be created some stuff still ends up a) trying to create tables (from PoisonQueueErrorHandler) and also when initializing the MySqlSubscriptionStorage it reads column schema data. So changed the code so that the table is not created if not requested when the poison error queue is created, and we defer to reading of the column widths from the subscription table until we actually need it. 99% of the time and 100% if the table was automatically created, the column widths will match the defaults.

With these changes if MySQL is down and Rebus is initialized in a process that is not reading messages (ie: code that just posts to it as a one way queue), we can avoid hitting the MySQL database so if it is down, we still come up just fine and can then resume operations when its up.

Clearly if MySQL is down and the code needs to read and process messages, or if automatic table creation is always enabled (we only enable this for our message processing queue code which is out of process to our web server code), it needs to fail. So this way if MySQL is down our web sites will still start just fine in a 'down for maintenance' state, while the actual message processing services will fail to start. We start those manually when MySQL is back up. Those will crash pretty quickly when MySQL is down, but the web site code is designed to gracefully produce a down for maintenance page if the database crashed out.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
