### PR TITLE
issues 1036

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,11 @@
 ## 2.0.1
 * Update to Rebus 6
 
+## 2.1.0
+* Update MySql.Data dep to 8.0.29 - thanks [dannythunder]
+
 
 [mvandevy]: https://github.com/mvandevy
 [renemadsen]: https://github.com/renemadsen
 [robvanpamel]: https://github.com/robvanpamel
+[dannythunder]: https://github.com/dannythunder

--- a/Rebus.MySql/Rebus.MySql.csproj
+++ b/Rebus.MySql/Rebus.MySql.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Rebus" Version="6.0.0" />
-    <PackageReference Include="MySql.Data" Version="8.0.12" />
+    <PackageReference Include="MySql.Data" Version="8.0.29" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Bumped the MySql.Data version to the latest as of today, 8.0.29.

Fix for issue:
[Issue 1036](rebus-org/Rebus.MySql#24)
---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
