### PR TITLE
Add protection against a pending message being consumed by multiple threads

### DIFF
--- a/Rebus.MySql/MySql/ExclusiveLocks/MySqlExclusiveAccessLock.cs
+++ b/Rebus.MySql/MySql/ExclusiveLocks/MySqlExclusiveAccessLock.cs
@@ -49,7 +49,7 @@ namespace Rebus.MySql.ExclusiveLocks
         /// Constructor
         /// </summary>
         /// <param name="connectionProvider">A <see cref="IDbConnection"/> to obtain a database connection</param>
-        /// <param name="lockTableName">Name of the queue this transport is servicing</param>
+        /// <param name="lockTableName">Name of the table to store the locks in</param>
         /// <param name="rebusLoggerFactory">A <seealso cref="IRebusLoggerFactory"/> for building loggers</param>
         /// <param name="asyncTaskFactory">A <seealso cref="IAsyncTaskFactory"/> for creating periodic tasks</param>
         /// <param name="rebusTime">A <seealso cref="IRebusTime"/> to provide the current time</param>
@@ -67,7 +67,7 @@ namespace Rebus.MySql.ExclusiveLocks
 
             _rebusTime = rebusTime ?? throw new ArgumentNullException(nameof(rebusTime));
             _connectionProvider = connectionProvider ?? throw new ArgumentNullException(nameof(connectionProvider));
-            _lockTableName = lockTableName != null ? TableName.Parse(lockTableName) : null;
+            _lockTableName = TableName.Parse(lockTableName ?? throw new ArgumentNullException(nameof(lockTableName)));
             _log = rebusLoggerFactory.GetLogger<MySqlExclusiveAccessLock>();
             _lockExpirationTimeout = options.LockExpirationTimeout ?? DefaultLockExpirationTimeout;
 
@@ -82,8 +82,6 @@ namespace Rebus.MySql.ExclusiveLocks
         /// </summary>
         public void Initialize()
         {
-            if (_lockTableName == null) return;
-
             _expiredLocksCleanupTask.Start();
         }
 


### PR DESCRIPTION
Add protection against a pending message being consumed by multiple threads somehow.

I believe there is a situation where multiple threads end up getting the same message as we have seen that in our logs. This is NOT supposed to happen with FOR UPDATE, as it is supposed to get a row level lock on the message in question so it should end up throwing a MySqlErrorCode.LockDeadlock transaction, which we ignore and continue. But somehow it looks like multiple threads grab the same message. Not sure if this is a MySQL bug, or a Percona XtraDB clustering issue or what, but we do seem to be seeing this. So to be 100% sure we are not grabbing a message already being processed in another thread, let's make sure leased_by is always null and bail if it is not.

---
Rebus is [MIT-licensed](https://opensource.org/licenses/MIT). The code submitted in this pull request needs to carry the MIT license too. By leaving this text in, __I hereby acknowledge that the code submitted in the pull request has the MIT license and can be merged with the Rebus codebase__.
